### PR TITLE
Add Installation-Instructions for Ubuntu too

### DIFF
--- a/docs/contributing_to_qiskit.rst
+++ b/docs/contributing_to_qiskit.rst
@@ -811,6 +811,12 @@ universally depending on operating system.
          .. code:: sh
 
             dnf install @development-tools
+            
+         For Ubuntu/Debian install it using:
+         
+         .. code:: sh
+            
+            apt-get install build-essential
 
       4. Install OpenBLAS development headers.
 
@@ -820,6 +826,12 @@ universally depending on operating system.
          .. code:: sh
 
             dnf install openblas-devel
+            
+         For Ubuntu/Debian install it using:
+         
+         .. code:: sh
+            
+            apt-get install libopenblas-dev
 
 
    .. tab:: macOS


### PR DESCRIPTION
### Summary

When installing Aer from source, it's necessary to install a c++ compiler and the openblas-headers. This PR adds the necessary package-names for Ubuntu, as they're currently only shown for Fedoras dnf.

### Details and comments

As Ubuntu is supported and the snippets are already mentioned in https://github.com/Qiskit/qiskit-aer/blob/master/CONTRIBUTING.md, they should also be shown in the official docs.